### PR TITLE
minor fix on filepath validation

### DIFF
--- a/pydtmc/validation.py
+++ b/pydtmc/validation.py
@@ -285,8 +285,6 @@ def validate_file_path(value: _tany, accepted_extensions: _olist_str, write_perm
     else:
         raise TypeError('The "@arg@" parameter must be a non-empty string or a path object.')
 
-    if not _osp.isfile(file_path):
-        raise ValueError('The "@arg@" parameter defines an invalid file path.')
 
     try:
         file_extension = _get_file_extension(file_path)
@@ -297,7 +295,10 @@ def validate_file_path(value: _tany, accepted_extensions: _olist_str, write_perm
         raise ValueError(f'The "@arg@" parameter must have one of the following extensions: {", ".join(sorted(accepted_extensions)).replace(".", "")}.')
 
     if write_permission:
-
+ 
+        if not _osp.isdir(_osp.dirname(file_path)) and _osp.isabs(file_path):
+            raise ValueError('The "@arg@" parameter defines a non-existent parent directory.')
+        
         try:
 
             with open(file_path, mode='w'):
@@ -307,6 +308,9 @@ def validate_file_path(value: _tany, accepted_extensions: _olist_str, write_perm
             raise ValueError('The "@arg@" parameter defines the path to an inaccessible file.') from ex
 
     else:
+
+        if not _osp.isfile(file_path):
+            raise ValueError('The "@arg@" parameter defines an invalid file path.')
 
         file_empty = False
 


### PR DESCRIPTION
## Description

When using chain.to_file(some_path), an issue was observed where a ValueError was raised with the message "The 'some_path' parameter defines an invalid file path".

The root cause of this problem was identified as the validate_file_path function. This function imposed a requirement for the file to already exist, which led to the aforementioned error when the file was not present.

## Motivation and Context

The existing behavior of validating the file's existence was found to be necessary when reading from a file using chain.from_file. However, this requirement should not apply when writing to a file. Instead, when writing to a file, the check should focus on ensuring the existence of the parent directory.

## Implementation
The changes made to address this issue are as follows:

1) Removal of the following block of code, which led to the error:
    
    if not _osp.isfile(file_path):
        raise ValueError('The "@arg@" parameter defines an invalid file path.')
 since this raised the error

To substitute the above deletion:
2) Introducing a new validation mechanism when writing to a file:
if write_permission:


        if not _osp.isdir(_osp.dirname(file_path)) and _osp.isabs(file_path):
            raise ValueError('The "@arg@" parameter defines a non-existent parent directory.')
3) Retaining the existing check for reading from a file:
    else:

        if not _osp.isfile(file_path):
            raise ValueError('The "@arg@" parameter defines an invalid file path.')

